### PR TITLE
feat: add url count

### DIFF
--- a/backend/src/main/java/dev/miguelhiguera/urlshortener/controllers/ShortenerController.java
+++ b/backend/src/main/java/dev/miguelhiguera/urlshortener/controllers/ShortenerController.java
@@ -44,4 +44,9 @@ public class ShortenerController {
         Url url = shortenerService.createShortUrl(urlDto);
         return "{\"url\":\"" + shortenerProperties.getBaseUrl() + "/" + url.getShortUrl() + "\"}";
     }
+
+    @GetMapping("/stats/count")
+    public String getUrlCount() {
+        return "{ \"count\": " + shortenerService.getUrlCount() + " }";
+    }
 }

--- a/backend/src/main/java/dev/miguelhiguera/urlshortener/services/ShortenerService.java
+++ b/backend/src/main/java/dev/miguelhiguera/urlshortener/services/ShortenerService.java
@@ -6,6 +6,7 @@ import dev.miguelhiguera.urlshortener.entities.Url;
 import java.util.Optional;
 
 public interface ShortenerService {
+    Long getUrlCount();
     String getOriginalUrlFromShortUrl(String shortUrl);
     Optional<Url> getUrlObjFromShortUrl(String shortUrl);
     Url createShortUrl(UrlDto urlDto);

--- a/backend/src/main/java/dev/miguelhiguera/urlshortener/services/ShortenerServiceImpl.java
+++ b/backend/src/main/java/dev/miguelhiguera/urlshortener/services/ShortenerServiceImpl.java
@@ -19,6 +19,11 @@ public class ShortenerServiceImpl implements ShortenerService {
     }
 
     @Override
+    public Long getUrlCount() {
+        return shortenerRepository.count();
+    }
+
+    @Override
     public String getOriginalUrlFromShortUrl(String shortUrl) {
         Optional<Url> optionalUrl = shortenerRepository.findByShortUrl(shortUrl);
 

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -1,0 +1,3 @@
+main {
+    min-height: calc(100vh - 120px);
+}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -3,3 +3,4 @@
   <app-shortener-form />
   <app-history />
 </main>
+<app-footer />

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -3,11 +3,12 @@ import { RouterOutlet } from '@angular/router';
 import { HeaderComponent } from './components/header/header.component';
 import { ShortenerFormComponent } from './components/shortener-form/shortener-form.component';
 import { HistoryComponent } from './components/history/history.component';
+import { FooterComponent } from './components/footer/footer.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, HeaderComponent, ShortenerFormComponent, HistoryComponent],
+  imports: [RouterOutlet, HeaderComponent, ShortenerFormComponent, HistoryComponent, FooterComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })

--- a/frontend/src/app/components/footer/footer.component.css
+++ b/frontend/src/app/components/footer/footer.component.css
@@ -1,0 +1,5 @@
+div {
+    padding: 16px;
+    font-size: 1rem;
+    font-weight: 500;
+}

--- a/frontend/src/app/components/footer/footer.component.css
+++ b/frontend/src/app/components/footer/footer.component.css
@@ -2,4 +2,5 @@ div {
     padding: 16px;
     font-size: 1rem;
     font-weight: 500;
+    text-align: center;
 }

--- a/frontend/src/app/components/footer/footer.component.css
+++ b/frontend/src/app/components/footer/footer.component.css
@@ -3,4 +3,10 @@ div {
     font-size: 1rem;
     font-weight: 500;
     text-align: center;
+    margin: 0;
+}
+
+a {
+    text-decoration: none;
+    color: black;
 }

--- a/frontend/src/app/components/footer/footer.component.html
+++ b/frontend/src/app/components/footer/footer.component.html
@@ -1,1 +1,1 @@
-<div>Generated URLs: 1,000</div>
+<div>Generated URLs: {{count}}</div>

--- a/frontend/src/app/components/footer/footer.component.html
+++ b/frontend/src/app/components/footer/footer.component.html
@@ -1,0 +1,1 @@
+<div>Generated URLs: 1,000</div>

--- a/frontend/src/app/components/footer/footer.component.html
+++ b/frontend/src/app/components/footer/footer.component.html
@@ -1,1 +1,1 @@
-<div>Generated URLs: {{count}}</div>
+<div>Made by <a href="https://github.com/miguelhigueradev" target="_blank">MiguelHigueraDev</a></div>

--- a/frontend/src/app/components/footer/footer.component.spec.ts
+++ b/frontend/src/app/components/footer/footer.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FooterComponent } from './footer.component';
+
+describe('FooterComponent', () => {
+  let component: FooterComponent;
+  let fixture: ComponentFixture<FooterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FooterComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(FooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/components/footer/footer.component.ts
+++ b/frontend/src/app/components/footer/footer.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  imports: [],
+  templateUrl: './footer.component.html',
+  styleUrl: './footer.component.css'
+})
+export class FooterComponent {
+
+}

--- a/frontend/src/app/components/footer/footer.component.ts
+++ b/frontend/src/app/components/footer/footer.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { UrlCountService } from '../../services/url-count.service';
 
 @Component({
   selector: 'app-footer',
@@ -8,5 +9,14 @@ import { Component } from '@angular/core';
   styleUrl: './footer.component.css'
 })
 export class FooterComponent {
+  constructor(private urlCountService: UrlCountService) {}
 
+  count = 0;
+
+  ngOnInit() {
+    this.urlCountService.getCount();
+    this.urlCountService.getCountObservable().subscribe((count) => {
+      this.count = count;
+    });
+  }
 }

--- a/frontend/src/app/components/footer/footer.component.ts
+++ b/frontend/src/app/components/footer/footer.component.ts
@@ -9,14 +9,6 @@ import { UrlCountService } from '../../services/url-count.service';
   styleUrl: './footer.component.css'
 })
 export class FooterComponent {
-  constructor(private urlCountService: UrlCountService) {}
+  constructor() {}
 
-  count = 0;
-
-  ngOnInit() {
-    this.urlCountService.getCount();
-    this.urlCountService.getCountObservable().subscribe((count) => {
-      this.count = count;
-    });
-  }
 }

--- a/frontend/src/app/components/header/header.component.css
+++ b/frontend/src/app/components/header/header.component.css
@@ -2,3 +2,19 @@
     display: flex;
     justify-content: space-between;
 }
+
+.head {
+    display: flex;
+    flex-direction: column;
+}
+
+.count {
+    font-size: 12px;
+    position: relative;
+    top: -2px;
+}
+
+.title {
+    position: relative;
+    top: 6px;
+}

--- a/frontend/src/app/components/header/header.component.html
+++ b/frontend/src/app/components/header/header.component.html
@@ -1,5 +1,8 @@
 <mat-toolbar color="primary" class="header">
-    <span>URL Shortener</span>
+    <div class="head">
+        <span class="title">URL Shortener</span>
+        <span class="count">{{count}} URLs Shortened!</span>
+    </div>
     <a mat-icon-button href="https://github.com/MiguelHigueraDev/url-shortener" target="_blank" aria-label="Visit GitHub repository">
         <!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
         <svg width="800px" height="800px" viewBox="0 -3.5 256 256" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMinYMin meet">

--- a/frontend/src/app/components/header/header.component.ts
+++ b/frontend/src/app/components/header/header.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import {MatIconModule} from '@angular/material/icon';
 import {MatButtonModule} from '@angular/material/button';
 import {MatToolbarModule} from '@angular/material/toolbar';
+import { UrlCountService } from '../../services/url-count.service';
 
 @Component({
   selector: 'app-header',
@@ -12,4 +13,14 @@ import {MatToolbarModule} from '@angular/material/toolbar';
 })
 export class HeaderComponent {
 
+  constructor(private urlCountService: UrlCountService) { }
+  
+  count = 0;
+
+  ngOnInit() {
+    this.urlCountService.getCount();
+    this.urlCountService.getCountObservable().subscribe((count) => {
+      this.count = count;
+    });
+  }
 }

--- a/frontend/src/app/components/shortener-form/shortener-form.component.ts
+++ b/frontend/src/app/components/shortener-form/shortener-form.component.ts
@@ -13,6 +13,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { HistoryService } from '../../services/history.service';
 import { RemoveHttpPipe } from '../../remove-http.pipe';
+import { UrlCountService } from '../../services/url-count.service';
 
 @Component({
   selector: 'app-shortener-form',
@@ -31,7 +32,7 @@ import { RemoveHttpPipe } from '../../remove-http.pipe';
   styleUrl: './shortener-form.component.css',
 })
 export class ShortenerFormComponent {
-  constructor(private shortenerService: ShortenerService, private historyService: HistoryService) {
+  constructor(private shortenerService: ShortenerService, private historyService: HistoryService, private urlCountService: UrlCountService) {
     // Update error message when input changes
     this.originalUrl.valueChanges.subscribe(() => {
       this.updateErrorMessage();
@@ -58,6 +59,7 @@ export class ShortenerFormComponent {
       .subscribe((response: any) => {
         this.shortenedUrl = response.url;
         this.historyService.addToHistory(this.shortenedUrl, this.originalUrl.value!);
+        this.urlCountService.getCount();
       });
   }
 

--- a/frontend/src/app/services/url-count.service.spec.ts
+++ b/frontend/src/app/services/url-count.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UrlCountService } from './url-count.service';
+
+describe('UrlCountService', () => {
+  let service: UrlCountService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UrlCountService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/services/url-count.service.ts
+++ b/frontend/src/app/services/url-count.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../environments/environment';
+import { BehaviorSubject } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+
+/**
+ * This service is responsible for counting the number of shortened URLs.
+ * It sends a GET request to the backend to get the count of shortened URLs.
+ * The backend returns the count of shortened URLs.
+ * The count is stored in a BehaviorSubject to listen to changes.
+ */
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UrlCountService {
+
+  constructor(private http: HttpClient) {}
+
+  private countUrl = environment.apiUrl + "/stats/count"
+  private countSubject = new BehaviorSubject<number>(0);
+
+  getCount() {
+    return this.http.get(this.countUrl, { responseType: 'json' }).subscribe((count: any) => {
+      this.countSubject.next(count.count);
+    });
+  }
+
+  getCountObservable() {
+    return this.countSubject.asObservable();
+  }
+}


### PR DESCRIPTION
Added the total number of URLs created.

![image](https://github.com/MiguelHigueraDev/url-shortener/assets/133175356/54cfea57-f5e8-4872-975c-6fe3080ede5a)

- Added a new `GET` endpoint (/stats/count) to retrieve the number of URLs
- Added the current number of URLs created to the header
- Added a basic footer